### PR TITLE
Settings string issues (+ Rapids owl check exclusion)

### DIFF
--- a/UI/main_window.py
+++ b/UI/main_window.py
@@ -323,7 +323,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.overworld_owls = True
             self.dungeon_owls = True
         
-        if not self.ui.rapidsCheck.isChecked():
+        if value in [1, 3] and not self.ui.rapidsCheck.isChecked():
             self.excluded_checks.update(['owl-statue-rapids'])
         
         self.updateSettingsString()
@@ -383,8 +383,15 @@ class MainWindow(QtWidgets.QMainWindow):
             self.progress_window.setStyleSheet(DARK_STYLESHEET)
         
         self.progress_window.show()
-    
-    
+
+    def getValidLocationChecks(self, locationList):
+        return [loc for loc in locationList
+                if (loc in DUNGEON_OWLS and self.dungeon_owls)
+                or (loc in OVERWORLD_OWLS and self.overworld_owls)
+                or (loc in BLUE_RUPEES and self.ui.rupCheck.isChecked())
+                or (loc not in DUNGEON_OWLS and loc not in OVERWORLD_OWLS and loc not in BLUE_RUPEES)
+                ]
+
     def tab_Changed(self):
 
         # starting items
@@ -406,23 +413,13 @@ class MainWindow(QtWidgets.QMainWindow):
         # locations
         if self.ui.tabWidget.currentIndex() == 2:
             self.ui.listWidget.clear()
-            for check in TOTAL_CHECKS.difference(self.excluded_checks):
-                if check in DUNGEON_OWLS and not self.dungeon_owls:
-                    continue
-                if check in OVERWORLD_OWLS and not self.overworld_owls:
-                    continue
-                if check in BLUE_RUPEES and not self.ui.rupCheck.isChecked():
-                    continue
+            checks = self.getValidLocationChecks(TOTAL_CHECKS.difference(self.excluded_checks))
+            for check in checks:
                 self.ui.listWidget.addItem(SmartListWidget(self.checkToList(str(check))))
             
             self.ui.listWidget_2.clear()
-            for check in self.excluded_checks:
-                if check in DUNGEON_OWLS and not self.dungeon_owls:
-                    continue
-                if check in OVERWORLD_OWLS and not self.overworld_owls:
-                    continue
-                if check in BLUE_RUPEES and not self.ui.rupCheck.isChecked():
-                    continue
+            checks = self.getValidLocationChecks(self.excluded_checks)
+            for check in checks:
                 self.ui.listWidget_2.addItem(SmartListWidget(self.checkToList(str(check))))
             
             return

--- a/UI/settings_manager.py
+++ b/UI/settings_manager.py
@@ -236,9 +236,9 @@ def encodeSettings(window) -> str:
             int_bytes.append(v)
         elif isinstance(v, list):
             if k == 'starting_gear':
-                comp = STARTING_ITEMS
+                comp = sorted(STARTING_ITEMS)
             elif k == 'excluded_locations':
-                comp = TOTAL_CHECKS
+                comp = sorted(TOTAL_CHECKS)
             settings_list = list(copy.deepcopy(settings_dict[k]))
             for c in comp:
                 list_bits.append(1 if c in settings_list else 0)
@@ -282,8 +282,8 @@ def decodeSettings(settings_str: str) -> dict:
     
     check_boxes = []
     nums_options = []
-    items = list(copy.deepcopy(STARTING_ITEMS))
-    locs = list(copy.deepcopy(TOTAL_CHECKS))
+    items = sorted(list(copy.deepcopy(STARTING_ITEMS)))
+    locs = sorted(list(copy.deepcopy(TOTAL_CHECKS)))
 
     for k,v in BASE_OPTIONS.items():
         if isinstance(v, bool):


### PR DESCRIPTION
This pull request fixes an issue with setting string being improperly encoded and decoded when using starting items and/or excluded locations because of lists order being random, making encoding/decoding impossible between application runs.

The quick'n'dirty solution here is to sort the lists right before encoding or decoding them.

This also fixes an issue with the rapids owl exclusion being made even if overworld owls were disabled causing a warning message to be shown.