### PR TITLE
Fix logic update link

### DIFF
--- a/RandomizerUI/update.py
+++ b/RandomizerUI/update.py
@@ -44,7 +44,7 @@ class LogicUpdateProcess(QtCore.QThread):
     def run(self):
         try:
             update_file =\
-                lib.urlopen("https://raw.githubusercontent.com/Owen-Splat/LAS-Randomizer/master/Data/logic.yml")
+                lib.urlopen("https://raw.githubusercontent.com/Owen-Splat/LAS-Randomizer/master/RandomizerCore/Data/logic.yml")
             web_version = float(update_file.readline().decode('utf-8').strip('#'))
             new_logic = update_file.read().decode('utf-8')
 


### PR DESCRIPTION
The link that is used to check logic update is wrong since the refactor. Updated it.

PS: Sorry about junk commits included in the MR, that must be because of the cherry pick in master for the recent logic update.